### PR TITLE
Pkgdown and Continuous Integration

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,6 @@
 ^vignettes/.*_cache/.*$
 ^tests/test/*$
 ^tests/testthat/Rplots.pdf$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+.github/
+

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,7 @@
 on:
   push:
     branches:
+      - master
       - pkgdown
 
 name: R-CMD-check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    branches:
+      - pkgdown
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GH_PAT }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+      - name: Install dependencies
+        run: |
+          options(pkgType = "binary")
+          options(install.packages.check.source = "no")
+          install.packages(c("remotes", "rcmdcheck", "covr", "pkgdown"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+      - name: Install package
+        run: R CMD INSTALL .
+      - name: Pkgdown
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,32 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GH_PAT }}
+    steps:
+      - uses: actions/checkout@master
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+      - name: Install dependencies
+        run: |
+          options(pkgType = "binary")
+          options(install.packages.check.source = "no")
+          install.packages(c("remotes", "rcmdcheck", "covr", "pkgdown"))
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+      - name: Check
+        run: rcmdcheck::rcmdcheck(args = "--no-manual", error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+      - name: Install package
+        run: R CMD INSTALL .
+      - name: Pkgdown
+        # Build the package site locally
+        run: Rscript -e 'pkgdown::build_site()'

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ inst/doc
 # Temporary files created by R markdown
 *.utf8.md
 *.knit.md
+
+# Package specific
 biomass\.Rproj
 vignettes/VignetteBiomass_cache/*
 tests/testthat/Rplots\.pdf
@@ -32,6 +34,6 @@ data-raw/climate_variable/wc2-5/
 vignettes/BIOMASS_cache/html/
 
 \.~*\#
-.Rproj.user
+
 # Web site
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ vignettes/BIOMASS_cache/html/
 
 \.~*\#
 .Rproj.user
+# Web site
+docs

--- a/BIOMASS.Rproj
+++ b/BIOMASS.Rproj
@@ -16,3 +16,4 @@ BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageCheckArgs: _R_CHECK_SUGGESTS_ONLY_=false
+PackageRoxygenize: rd,collate,namespace

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BIOMASS
 Type: Package
 Title: Estimating Aboveground Biomass and Its Uncertainty in Tropical Forests
-Version: 2.1.12
+Version: 2.1.12.9000
 Date: 2024-02-09
 Authors@R: c(
 	person("Maxime", "Réjou-Méchain", email = "maxime.rejou@gmail.com", role = c("aut", "dtc")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: BIOMASS
 Type: Package
 Title: Estimating Aboveground Biomass and Its Uncertainty in Tropical Forests
-Version: 2.1.12.9000
+Version: 2.1.13
 Date: 2024-02-09
 Authors@R: c(
 	person("Maxime", "Réjou-Méchain", email = "maxime.rejou@gmail.com", role = c("aut", "dtc")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Encoding: UTF-8
 LazyData: true
 Depends: R(>= 3.6)
 Roxygen: list(markdown = TRUE)
-URL: https://github.com/umr-amap/BIOMASS
+URL: https://umr-amap.github.io/BIOMASS, https://github.com/umr-amap/BIOMASS
 BugReports: https://github.com/umr-amap/BIOMASS/issues
 Imports:
 	minpack.lm, 
@@ -48,5 +48,6 @@ Suggests:
 	testthat,
 	curl,
 	geodata,
-	httr2
+	httr2,
+	pkgdown
 RoxygenNote: 7.3.1

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-* version 2.1.12.9000
+* version 2.1.13
 - Activate pkgdown
 
 * version 2.1.12

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+* version 2.1.12.9000
+- Activate pkgdown
+
 * version 2.1.12
 - fix missing export of function predictHeight
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,7 @@
+url: https://umr-amap.github.io/BIOMASS/
+
+template:
+  bootstrap: 5
+
+development:
+  mode: auto

--- a/man/BIOMASS-package.Rd
+++ b/man/BIOMASS-package.Rd
@@ -152,6 +152,7 @@ Methods in Ecology and Evolution, 8(9), 1163-1167.
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://umr-amap.github.io/BIOMASS}
   \item \url{https://github.com/umr-amap/BIOMASS}
   \item Report bugs at \url{https://github.com/umr-amap/BIOMASS/issues}
 }


### PR DESCRIPTION
I activated pkgdown: https://ericmarcon.github.io/BIOMASS/ contains the preview of  https://github.com/umr-amap.github.io/BIOMASS/

I also activated continuous integration to check the package and produce the pkgdown site in the `gh-pages` branch.

Before merging, a personal access token named `GH_PAT` must be saved in the project's settings (Settings/Secrets and Variables/Actions) : it is used by `.github/workflows/check.yml`

After merging, delete line 5 of `.github/workflows/check.yml` that contains the name of the merged branch.