### PR TITLE
Close httr2 stream connection

### DIFF
--- a/R/cacheManager.R
+++ b/R/cacheManager.R
@@ -62,6 +62,7 @@ cacheManager <- function(nameFile) {
     message("There appears to be a problem reaching the directory.")
     return(invisible(NULL))
   }
+  close(qryResult)
   
   if(!file.exists(cachePath(nameFile))) {
     dest <- tempfile(fileext = ".zip")


### PR DESCRIPTION
Previously, stream connections opened by `qryResult <- httr2::req_perform_connection(req)` in `cacheManager()` were not closed. 

Running `AGBmonteCarlo()` more than 42 times within a single session tested the default limit of 128 open connections.

Added `close(qryResult)` to `cacheManager()` to prevent this error.
