### PR TITLE
Revert "Allow input WFO ID when no candidates, interactive"

### DIFF
--- a/R/correctTaxo.R
+++ b/R/correctTaxo.R
@@ -113,38 +113,10 @@ callAPI <- function(vars, query, capacity = 60, fill_time_s = 60, timeout = 10) 
 #' 
 pickName <- function(x, cand, offset = 0, page_size = 10, timeout = 10) {
 
-  # Initialise while loops
-  valid <- FALSE
-
-  # If no candidates, prompt for WFO ID
+  # If no candidates, SKIP
   if (length(cand) == 0) {
-    cat(sprintf("\n\nNo candidates for: %s\n", x))
-    while (!valid) {
-      # Prompt user for input
-      prompt <- "Enter a valid WFO ID, 'S', or press Enter to skip. "
-      input <- tolower(trimws(readline(prompt)))
-
-      # If a valid WFO ID, search for that
-      if (grepl("^wfo-[0-9]{10}$", tolower(trimws(input)))) {
-        api_vars <- list(searchString = input)
-        api_call <- callAPI(api_vars, 
-          query_taxonNameById(), timeout = timeout)
-        api_resp <- httr2::req_perform(api_call)
-        api_json <- httr2::resp_body_json(api_resp)
-        match <- api_json$data$taxonNameById
-        match$method <- "MANUAL"
-        valid <- TRUE
-      # If skipped deliberately by user
-      } else if (tolower(input) %in% c("s", "")) {
-        match <- list(method = "SKIP")
-        valid <- TRUE
-      # If invalid input
-      } else {
-        cat("Invalid input.\n")
-      }
-    }
-
-    # Return
+    message(sprintf("No candidates, skipping: %s", x))
+    match <- list(method = "EMPTY")
     return(match)
   }
 
@@ -165,15 +137,16 @@ pickName <- function(x, cand, offset = 0, page_size = 10, timeout = 10) {
       sprintf(
         "%-4s%s\t%s\t%s\t%s\t%s\n",
         i,
-        null2na(cand[[i]]$id),
-        null2na(cand[[i]]$fullNameStringNoAuthorsPlain),
-        null2na(cand[[i]]$authorsString),
-        null2na(cand[[i]]$role),
-        null2na(cand[[i]]$wfoPath)
+        cand[[i]]$id,
+        cand[[i]]$fullNameStringNoAuthorsPlain,
+        cand[[i]]$authorsString,
+        cand[[i]]$role,
+        cand[[i]]$wfoPath
       )
     )
   }
 
+  valid <- FALSE
   while (!valid) {
 
     # Create footer
@@ -182,7 +155,7 @@ pickName <- function(x, cand, offset = 0, page_size = 10, timeout = 10) {
       "a valid WFO ID,", 
       "'N' for the next page,", 
       "'P' for the previous page,",
-      "'S' or press Enter to skip: ")
+      "'S' to skip this name: ")
 
     # Prompt the user for input
     input <- trimws(readline(prompt))
@@ -194,10 +167,10 @@ pickName <- function(x, cand, offset = 0, page_size = 10, timeout = 10) {
       match$method <- "MANUAL"
       valid <- TRUE
     } else if (grepl("^wfo-[0-9]{10}$", tolower(trimws(input)))) {
+      # Prepare body of call
       input <- tolower(trimws(input))
       api_vars <- list(searchString = input)
-      api_call <- callAPI(api_vars, 
-        query_taxonNameById(), timeout = timeout)
+      api_call <- callAPI(api_vars, query_taxonNameById(), timeout = timeout)
       api_resp <- httr2::req_perform(api_call)
       api_json <- httr2::resp_body_json(api_resp)
       match <- api_json$data$taxonNameById
@@ -219,7 +192,7 @@ pickName <- function(x, cand, offset = 0, page_size = 10, timeout = 10) {
       match <- list(method = "SKIP")
       valid <- TRUE
     } else {
-      cat("Invalid input.\n")
+      cat("Invalid input. Enter an integer, a valid WFO ID, 'N', 'P', 'S', or press Enter to skip.\n" )
     }
   }
 

--- a/tests/testthat/test-correctTaxo.R
+++ b/tests/testthat/test-correctTaxo.R
@@ -94,18 +94,9 @@ test_that("correctTaxo uses cache and avoids API calls when possible", {
     )
   )
   
-  # checkURL returns TRUE always, 
-  # to simulate reachable API without pinging API
-  mockery::stub(correctTaxo, "checkURL", TRUE)
-
-  # Simulate backbone version without pinging API 
-  mock_bb <- list(data = list(classifications = list(id = "v2023.12")))
-  mockery::stub(correctTaxo, "httr2::req_perform", mockery::mock(mock_bb))
-  mockery::stub(correctTaxo, "httr2::resp_body_json", mockery::mock(mock_bb))
-  
   # Choose cached value 
   expect_equal(
-    correctTaxo("Burkea", "africana", useCache = TRUE, useAPI = TRUE, 
+    correctTaxo("Burkea", "africana", useCache = TRUE, useAPI = FALSE, 
       interactive = FALSE)$nameMatched, 
     "TEST")
 })
@@ -392,13 +383,12 @@ test_that("pickName handles empty string as skip", {
 # pickName - empty input
 test_that("pickName exits early if no candidates provided", {
   # Simulate empty candidate list
-  m <- mockery::mock()
+  m <- mockery::mock("s")
   mockery::stub(pickName, "readline", m)
   
   # Empty candidates list triggers "EMPTY" and exit 
-  expect_message(res <- pickName("Fake Name", list()), "No candidates, skipping")
-  expect_equal(res$method, "EMPTY")
-  mockery::expect_called(m, 0)
+  res <- pickName("Fake Name", list())
+  expect_equal(res$method, "SKIP")
 })
 
 # pickName - handle selecting candidate by number


### PR DESCRIPTION
Reverts umr-amap/BIOMASS#88 : test failure 